### PR TITLE
added multi-threading for responsiveness

### DIFF
--- a/p2_swb4062_Server/p2_swb4062_Server/Form1.cs
+++ b/p2_swb4062_Server/p2_swb4062_Server/Form1.cs
@@ -1,4 +1,4 @@
-﻿/*  
+/*  
 Author:         Stephen Blanchard
 CLID:           swb4062
 Class:          CMPS 358
@@ -33,18 +33,32 @@ namespace p2_swb4062_Server
             Program.listener = new TcpListener(IPAddress.Any, 51111);
             Program.listener.Start();
         }
+        private int timeCount = 0;
         //The start game button hides the connection window and open up the game window to begin ship placement
         private void bStart_Click(object sender, EventArgs e)
         {
+            int timeoutCount = 0;
                 try
                 {
-                    Program.c = Program.listener.AcceptTcpClient();
-                    if (Program.c.Connected)
+                    //multi-threading so gui will remain responsive while connection is attempted
+                    //thread 1 is where the program actually listens for the client
+                    Thread t1 = new Thread(() =>
+                    {
+                        using (Program.c = Program.listener.AcceptTcpClient()) ;
+                    });
+
+                    //thread 2 is the portion of code that is executed if the is successful
+                    Thread t2 = new Thread(() =>
                     {
                         lStatus2.Text = "Client successfully connected!";
                         Program.n = Program.c.GetStream();
                         this.Hide();
                         new Form2().Show();
+                    });
+                    t1.Start();
+                    if (Program.c.Connected)
+                    {
+                        t2.Start();
                     }
                 }
                 catch
@@ -53,5 +67,6 @@ namespace p2_swb4062_Server
                 }
             
         }
+
     }
 }


### PR DESCRIPTION
If the start game button was hit while listening for the client, the gui would freeze because the GUI and the listening were happening on the same thread. I added multithreading to form1 of server so that the actions are taking place on different threads
